### PR TITLE
Add synopsys detect exit codes and exit code names as detect-action o…

### DIFF
--- a/src/detect/exit-codes.ts
+++ b/src/detect/exit-codes.ts
@@ -1,2 +1,20 @@
-export const SUCCESS = 0
-export const POLICY_SEVERITY = 3
+export enum DETECT_EXIT_CODES {
+  NO_DETECT_EXIT_CODE = -1, // not a detect exit code but used for error handling
+  SUCCESS = 0, // Detect exited successfully.
+  FAILURE_BLACKDUCK_CONNECTIVITY = 1, // Detect was unable to connect to Black Duck. Check your configuration and connection.
+  FAILURE_TIMEOUT = 2, // Detect was unable to wait for actions to be completed on Black Duck. Check your Black Duck server or increase your timeout.
+  FAILURE_POLICY_VIOLATION = 3, // Detect found policy violations.
+  FAILURE_PROXY_CONNECTIVITY = 4, // Detect was unable to use the configured proxy. Check your configuration and connection.
+  FAILURE_DETECTOR = 5, // Detect had one or more detector failures while extracting dependencies. Check that all projects build and your environment is configured correctly.
+  FAILURE_SCAN = 6, // Detect was unable to run the signature scanner against your source. Check your configuration.
+  FAILURE_CONFIGURATION = 7, // Detect was unable to start due to issues with it's configuration. Check and fix your configuration.
+  FAILURE_DETECTOR_REQUIRED = 9, //Detect did not run all of the required detectors. Fix detector issues or disable required detectors.
+  FAILURE_BLACKDUCK_VERSION_NOT_SUPPORTED = 10, // Detect's configuration requires a Black Duck capability that is not supported by your version of Black Duck. Ensure that your Black Duck version is compatible with this version of Detect.
+  FAILURE_BLACKDUCK_FEATURE_ERROR = 11, // Detect encountered an error while attempting an operation on Black Duck. Ensure that your Black Duck version is compatible with this version of Detect, and that your Black Duck user account has the required roles.
+  FAILURE_MINIMUM_INTERVAL_NOT_MET = 13, // Detect did not wait the minimum required scan interval.
+  FAILURE_IAC = 14, // Detect was unable to perform IaC Scan against your source. Please check your configuration, and see logs and IaC Scanner documentation for more information.
+  FAILURE_ACCURACY_NOT_MET = 15, // Detect was unable to meet the required accuracy.
+  FAILURE_IMAGE_NOT_AVAILABLE = 20, //Image scan attempted but no return data available.
+  FAILURE_GENERAL_ERROR = 99, // Detect encountered a known error, details of the error are provided.
+  FAILURE_UNKNOWN_ERROR = 100 // Detect encountered an unknown error.
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,11 +1,11 @@
-import { info, warning, setFailed, debug } from '@actions/core'
+import { info, warning, setFailed, debug, setOutput } from '@actions/core'
 import { create } from '@actions/glob'
 import path from 'path'
 import fs from 'fs'
 import { BlackduckApiService, IBlackduckView, IRapidScanResults } from './blackduck-api'
 import { createCheck, GitHubCheck } from './github/check'
 import { commentOnPR } from './comment'
-import { POLICY_SEVERITY, SUCCESS } from './detect/exit-codes'
+import { DETECT_EXIT_CODES } from './detect/exit-codes'
 import { TOOL_NAME, findOrDownloadDetect, runDetect } from './detect/detect-manager'
 import { isPullRequest } from './github/github-context'
 import { BLACKDUCK_API_TOKEN, BLACKDUCK_URL, DETECT_TRUST_CERT, DETECT_VERSION, FAIL_ON_ALL_POLICY_SEVERITIES, OUTPUT_PATH_OVERRIDE, SCAN_MODE } from './inputs'
@@ -18,8 +18,14 @@ export async function run() {
   runWithPolicyCheck(blackduckPolicyCheck).catch(unhandledError => {
     debug('Canceling policy check because of an unhandled error.')
     blackduckPolicyCheck.cancelCheck()
-    setFailed(`Failed due to an unhandled error: '${unhandledError}'`)
+    setFailedInternal(`Failed due to an unhandled error: '${unhandledError}'`)
   })
+}
+
+function setFailedInternal(message: string, detectExitCode: DETECT_EXIT_CODES = DETECT_EXIT_CODES.NO_DETECT_EXIT_CODE): void {
+  setFailed(message)
+  setOutput('detect-exit-code', detectExitCode)
+  setOutput('detect-exit-code-name', DETECT_EXIT_CODES[detectExitCode])
 }
 
 export async function runWithPolicyCheck(blackduckPolicyCheck: GitHubCheck): Promise<void> {
@@ -38,7 +44,7 @@ export async function runWithPolicyCheck(blackduckPolicyCheck: GitHubCheck): Pro
   if (OUTPUT_PATH_OVERRIDE !== '') {
     outputPath = OUTPUT_PATH_OVERRIDE
   } else if (runnerTemp === undefined) {
-    setFailed('$RUNNER_TEMP is not defined and output-path-override was not set. Cannot determine where to store output files.')
+    setFailedInternal('$RUNNER_TEMP is not defined and output-path-override was not set. Cannot determine where to store output files.')
     blackduckPolicyCheck.cancelCheck()
     return
   } else {
@@ -50,8 +56,8 @@ export async function runWithPolicyCheck(blackduckPolicyCheck: GitHubCheck): Pro
 
     const blackduckApiService = new BlackduckApiService(BLACKDUCK_URL, BLACKDUCK_API_TOKEN)
     const blackDuckBearerToken = await blackduckApiService.getBearerToken()
-    let policiesExist: boolean | void = await blackduckApiService.checkIfEnabledBlackduckPoliciesExist(blackDuckBearerToken).catch(reason => {
-      setFailed(`Could not verify whether policies existed: ${reason}`)
+    const policiesExist: boolean | void = await blackduckApiService.checkIfEnabledBlackduckPoliciesExist(blackDuckBearerToken).catch(reason => {
+      setFailedInternal(`Could not verify whether policies existed: ${reason}`)
     })
 
     if (policiesExist === undefined) {
@@ -59,7 +65,7 @@ export async function runWithPolicyCheck(blackduckPolicyCheck: GitHubCheck): Pro
       blackduckPolicyCheck.cancelCheck()
       return
     } else if (!policiesExist) {
-      setFailed(`Could not run ${TOOL_NAME} using ${SCAN_MODE} scan mode. No enabled policies found on the specified Black Duck server.`)
+      setFailedInternal(`Could not run ${TOOL_NAME} using ${SCAN_MODE} scan mode. No enabled policies found on the specified Black Duck server.`)
       return
     } else {
       info(`You have at least one enabled policy, executing ${TOOL_NAME} in ${SCAN_MODE} scan mode...`)
@@ -69,7 +75,7 @@ export async function runWithPolicyCheck(blackduckPolicyCheck: GitHubCheck): Pro
   const detectArgs = [`--blackduck.trust.cert=${DETECT_TRUST_CERT}`, `--blackduck.url=${BLACKDUCK_URL}`, `--blackduck.api.token=${BLACKDUCK_API_TOKEN}`, `--detect.blackduck.scan.mode=${SCAN_MODE}`, `--detect.output.path=${outputPath}`, `--detect.scan.output.path=${outputPath}`]
 
   const detectPath = await findOrDownloadDetect().catch(reason => {
-    setFailed(`Could not download ${TOOL_NAME} ${DETECT_VERSION}: ${reason}`)
+    setFailedInternal(`Could not download ${TOOL_NAME} ${DETECT_VERSION}: ${reason}`)
   })
 
   if (detectPath === undefined) {
@@ -79,15 +85,15 @@ export async function runWithPolicyCheck(blackduckPolicyCheck: GitHubCheck): Pro
   }
 
   const detectExitCode = await runDetect(detectPath, detectArgs).catch(reason => {
-    setFailed(`Could not execute ${TOOL_NAME} ${DETECT_VERSION}: ${reason}`)
+    setFailedInternal(`Could not execute ${TOOL_NAME} ${DETECT_VERSION}: ${reason}`)
   })
 
   if (detectExitCode === undefined) {
     debug(`Could not determine ${TOOL_NAME} exit code. Canceling policy check.`)
     blackduckPolicyCheck.cancelCheck()
     return
-  } else if (detectExitCode > 0 && detectExitCode != POLICY_SEVERITY) {
-    setFailed(`Detect failed with exit code: ${detectExitCode}. Check the logs for more information.`)
+  } else if (detectExitCode > 0 && detectExitCode != DETECT_EXIT_CODES.FAILURE_POLICY_VIOLATION) {
+    setFailedInternal(`Detect failed with exit code: ${detectExitCode}. Check the logs for more information.`, detectExitCode)
     return
   }
 
@@ -109,7 +115,7 @@ export async function runWithPolicyCheck(blackduckPolicyCheck: GitHubCheck): Pro
     hasPolicyViolations = policyViolations.length > 0
     debug(`Policy Violations Present: ${hasPolicyViolations}`)
 
-    const failureConditionsMet = detectExitCode === POLICY_SEVERITY || FAIL_ON_ALL_POLICY_SEVERITIES
+    const failureConditionsMet = detectExitCode === DETECT_EXIT_CODES.FAILURE_POLICY_VIOLATION || FAIL_ON_ALL_POLICY_SEVERITIES
     const rapidScanReport = await createRapidScanReportString(policyViolations, hasPolicyViolations && failureConditionsMet)
 
     if (isPullRequest()) {
@@ -145,7 +151,7 @@ export async function runWithPolicyCheck(blackduckPolicyCheck: GitHubCheck): Pro
     warning('Found dependencies violating policy!')
   } else if (detectExitCode > 0) {
     warning('Dependency check failed! See Detect output for more information.')
-  } else if (detectExitCode === SUCCESS) {
+  } else if (detectExitCode === DETECT_EXIT_CODES.SUCCESS) {
     info('None of your dependencies violate your Black Duck policies!')
   }
 }


### PR DESCRIPTION
…utput.

As a developer, I want to react upon different outcomes of the detect scan.
By use of the exit codes, I can (or avoid to) run further actions after the detect scan finished.

**Example**
```yaml
- name: 🦆 Run Detect Scan
   id: scan
   uses: synopsys-sig/detect-action@v0.3.3
   env:
     DETECT_PROJECT_VERSION_NAME: 'master'
     DETECT_RISK_REPORT_PDF: true
     DETECT_RISK_REPORT_PDF_PATH: '.'
   with:
     scan-mode: 'RAPID'
     github-token: ${{ github.token }}
     detect-version: 7.9.0
     blackduck-url: 'https://my.blackduck.url.com'
     blackduck-api-token: ${{ secrets.BLACKDUCK_API_TOKEN }}
- name: Post Action
   if: ${{ always() }}
   shell: bash
   run: |
     echo ${{ steps.scan.outputs.detect-exit-code }}
     echo ${{ steps.scan.outputs.detect-exit-code-name }}
```