### PR TITLE
Reduce the noise that's created by PR comments

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -119,7 +119,7 @@ export async function runWithPolicyCheck(blackduckPolicyCheck: GitHubCheck): Pro
 
     if (isPullRequest()) {
       info('This is a pull request, commenting...')
-      commentOnPR(rapidScanReport)
+      commentOnPR(rapidScanReport, hasPolicyViolations)
       info('Successfully commented on PR.')
     }
 


### PR DESCRIPTION
The current functionality for creating/recreating comments is pretty noisy:

* A comment is created on every PR even if there are no policy violations
* Comments are deleted / re-created after every commit, even if the contents of the comment haven't changed

I've changed the functionality such that comments are only created if:

* There are policy violations and the content of the rapid scan report have changed since the last comment (or if there is no previous comment)
* There are no policy violations but there were previously