### PR TITLE
chore(deps): upgrade node to version 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,5 +31,5 @@ inputs:
     description: 'Acceptable Values: TRUE, FALSE. If TRUE, Detect will trust the Black Duck certificate even if the certificate is not in the keystore.'
     default: 'TRUE'
 runs:
-  using: 'node12'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
this action still uses node12

Refs:
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/


