### PR TITLE
fix: Updating the message if no violating policies are found

### DIFF
--- a/src/detect/reporting.ts
+++ b/src/detect/reporting.ts
@@ -6,7 +6,7 @@ export const TABLE_HEADER = '| Policies Violated | Dependency | License(s) | Vul
 export async function createRapidScanReportString(policyViolations: IRapidScanResults[], policyCheckWillFail: boolean): Promise<string> {
   let message = ''
   if (policyViolations.length == 0) {
-    message = message.concat('# :white_check_mark: None of your dependencies violate policy!')
+    message = message.concat('# :white_check_mark: None of your dependencies violate your Black Duck policies!')
   } else {
     const violationSymbol = policyCheckWillFail ? ':x:' : ':warning:'
     message = message.concat(`# ${violationSymbol} Found dependencies violating policy!\r\n\r\n`)


### PR DESCRIPTION
This will ease up the developers to know what scanning source have commented on the PR. If there are multiple github comments on the PR then it will be easy for the developer to know this comment has come from the Blackduck PR scans